### PR TITLE
hotfix: remove pull_request trigger from documentation workflow

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -6,7 +6,6 @@ on:
     paths:
       - 'docs/**'
       - 'src/**'
-  pull_request:
   workflow_dispatch:
 jobs:
   Build:


### PR DESCRIPTION
### Summary
This hotfix removes the `pull_request` trigger from the documentation GitHub Actions workflow. 
The action was previously running for all pull requests, including those targeting `develop`, which is unnecessary and wasteful.

### Changes
- Removed `pull_request:` from `.github/workflows/documentation.yml`

### Reason
The documentation workflow is only relevant for changes merged into `master` that affect the `docs/` or `src/` folders. 
Running it for every PR, especially to `develop`, leads to unnecessary CI runs.

### Impact
- Reduces CI usage and noise
- Aligns workflow behaviour with our Git Flow strategy
- Prevents misleading documentation builds during development

### Next Steps
After merging this hotfix into `master`, merge `master` back into `develop` to ensure the fix is reflected in the development branch.